### PR TITLE
Cleanups toward removing items to external asset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +149,9 @@ name = "gmtk_2023_escape_room"
 version = "0.1.0"
 dependencies = [
  "macroquad",
+ "ron",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -324,6 +333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "quad-alsa-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +370,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,10 +425,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 macroquad = "0.3.26"
+ron = "0.8.0"
+serde = { version = "1.0.171", features = ["derive"] }
+serde_derive = "1.0.171"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
+use std::ops::Add;
+use std::collections::HashMap;
+
 use macroquad::input::{is_mouse_button_pressed, mouse_position, MouseButton};
 use macroquad::prelude::*;
 use macroquad::texture::Texture2D;
-use std::ops::Add;
 
 use serde::Deserializer;
 use serde::de::{self, Visitor};
@@ -138,7 +140,7 @@ struct Item {
     position: Pos,
     state: ItemState,
     flavor_text: Vec<String>,
-    link: Option<Box<Item>>,
+    link: Option<String>,
 }
 
 impl Item {
@@ -149,7 +151,7 @@ impl Item {
         position: Pos,
         state: ItemState,
         flavor_text: Vec<&str>,
-        link: Option<Box<Item>>,
+        link: Option<String>,
     ) -> Self {
         Item {
             room,
@@ -255,7 +257,7 @@ async fn main() {
         Pos::new(100f32, 0f32),
         ItemState::Interact,
         vec![""],
-        Some(Box::new(door_pad.clone())),
+        Some("door_pad".to_owned()),
     );
     items.push(door);
 
@@ -291,7 +293,7 @@ async fn main() {
         Pos::new(50f32, 335f32),
         ItemState::Look,
         vec![""],
-        Some(Box::new(north_open_book.clone())),
+        Some("north_open_book".to_owned()),
     );
     items.push(north_closed_book);
 
@@ -315,7 +317,7 @@ async fn main() {
         Pos::new(460f32, 225f32),
         ItemState::Look,
         vec![""],
-        Some(Box::new(north_big_painting.clone())),
+        Some("north_big_painting".to_owned()),
     );
     items.push(north_small_painting);
 
@@ -339,7 +341,7 @@ async fn main() {
         Pos::new(420f32, 25f32),
         ItemState::Look,
         vec![""],
-        Some(Box::new(big_clock.clone())),
+        Some("big_clock".to_owned()),
     );
     items.push(small_clock);
 
@@ -365,7 +367,7 @@ async fn main() {
         Pos::new(100f32, 50f32),
         ItemState::Interact,
         vec![""],
-        Some(Box::new(phone_entry.clone())),
+        Some("phone_entry".to_owned()),
     );
     items.push(phonebooth);
 
@@ -400,7 +402,7 @@ async fn main() {
         Pos::new(175f32, 300f32),
         ItemState::Look,
         vec![""],
-        Some(Box::new(east_book.clone())),
+        Some("east_book".to_owned()),
     );
     items.push(east_closed_book);
 
@@ -424,7 +426,7 @@ async fn main() {
         Pos::new(360f32, 175f32),
         ItemState::Look,
         vec![""],
-        Some(Box::new(east_big_painting.clone())),
+        Some("east_big_painting".to_owned()),
     );
     items.push(east_small_painting);
 
@@ -459,7 +461,7 @@ async fn main() {
         Pos::new(460f32, 350f32),
         ItemState::Interact,
         vec![""],
-        Some(Box::new(colormatch).clone()),
+        Some("colormatch".to_owned()),
     );
     items.push(colorbox);
 
@@ -485,7 +487,7 @@ async fn main() {
         Pos::new(50f32, 300f32),
         ItemState::Look,
         vec![""],
-        Some(Box::new(weight_big).clone()),
+        Some("weight_big".to_string()),
     );
     items.push(weights_small);
 
@@ -520,7 +522,7 @@ async fn main() {
         Pos::new(460f32, 325f32),
         ItemState::Look,
         vec![""],
-        Some(Box::new(paint_numbers_big).clone()),
+        Some("paint_numbers_big".to_owned()),
     );
     items.push(paint_numbers_small);
 
@@ -567,7 +569,7 @@ async fn main() {
         Pos::new(390f32, 95f32),
         ItemState::Interact,
         vec![""],
-        Some(Box::new(safe_big).clone()),
+        Some("safe_big".to_owned()),
     );
     items.push(safe_small);
 
@@ -605,7 +607,7 @@ async fn main() {
         Pos::new(140f32, 310f32),
         ItemState::Look,
         vec![""],
-        Some(Box::new(vase_big).clone()),
+        Some("vase_big".to_owned()),
     );
     items.push(vase_small);
 
@@ -640,7 +642,7 @@ async fn main() {
         Pos::new(340f32, 160f32),
         ItemState::Interact,
         vec![""],
-        Some(Box::new(candlecase_big).clone()),
+        Some("candlecase_big".to_owned()),
     );
     items.push(candlecase_small);
 
@@ -669,9 +671,20 @@ async fn main() {
         Pos::new(400f32, 325f32),
         ItemState::Interact,
         vec![""],
-        Some(Box::new(codeentry_big).clone()),
+        Some("codeentry_big".to_owned()),
     );
     items.push(codeentry_small);
+
+    let mut tag_map: HashMap<String, Item> = items
+        .into_iter()
+        .map(|item| (item.tag.clone(), item))
+        .collect();
+
+    fn lookup(tag_map: &HashMap<String, Item>, option_item: &Option<Item>) -> Item {
+        let link = &option_item.as_ref().unwrap().link;
+        let tag: &str = link.as_ref().unwrap();
+        tag_map[tag].clone()
+    }
 
     let code_apple: Texture2D = load_texture("assets/CodeApple.png").await.unwrap();
     let code_beaver: Texture2D = load_texture("assets/CodeBeaver.png").await.unwrap();
@@ -731,7 +744,7 @@ async fn main() {
 
             // Main items loop, for drawing and clicking
 
-            for item in &items {
+            for item in tag_map.values() {
                 if item.room != current_room {
                     continue;
                 }
@@ -802,7 +815,7 @@ async fn main() {
 
             // Show linked item
 
-            let item = current_item.clone().unwrap().link.unwrap().clone();
+            let item = lookup(&tag_map, &current_item);
             draw_texture(
                 *item.texture,
                 item.position.x,
@@ -829,7 +842,7 @@ async fn main() {
 
             // Do main texture drawing
 
-            let item = current_item.clone().unwrap().link.unwrap().clone();
+            let item = lookup(&tag_map, &current_item);
             draw_texture(
                 *item.texture,
                 item.position.x,
@@ -873,7 +886,7 @@ async fn main() {
                                 vec!["You know, I don't really", "feel like leaving, actually."],
                                 None,
                             );
-                            items.push(open_door);
+                            tag_map.insert(open_door.tag.to_owned(), open_door);
 
                             main_text = vec!["The door opened!".to_string()];
                             current_state = UserState::Nothing;
@@ -1105,7 +1118,7 @@ async fn main() {
                                 vec![""],
                                 None,
                             );
-                            items.push(safe_big.clone());
+                            tag_map.insert(safe_big.tag.clone(), safe_big.clone());
 
                             let safe_small_texture: Texture2D = load_texture("assets/OpenSafeSmall.png").await.unwrap();
                             let safe_small = Item::new(
@@ -1115,9 +1128,9 @@ async fn main() {
                                 Pos::new(390f32, 95f32),
                                 ItemState::Look,
                                 vec![""],
-                                Some(Box::new(safe_big.clone())),
+                                Some("safe_big".to_owned()),
                             );
-                            items.push(safe_small);
+                            tag_map.insert(safe_small.tag.clone(), safe_small.clone());
 
                             main_text = vec!["The safe opened!".to_string()];
                             current_state = UserState::Nothing;


### PR DESCRIPTION
Put in support for `Item` deserialization from [Ron](https://github.com/ron-rs/ron); changed `Item` link structure and handling to allow string links in Ron.